### PR TITLE
Remove Commons IO as runtime dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,7 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.6</version>
+      <scope>test</scope>
     </dependency>
     <!-- JUnit -->
     <dependency>


### PR DESCRIPTION
The Apache Commons IO library is only used by the tests. Removing it from the runtime dependencies causes downstream classpaths to not be as populated, application sizes to be smaller, and startup times to be faster.