### PR TITLE
Point the POM at the correct license

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
   <url>https://github.com/ctabin/jotlmsg</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <name>BSD-3-Clause</name>
+      <url>https://raw.githubusercontent.com/ctabin/jotlmsg/jotlmsg-${version}/LICENCE</url>
     </license>
   </licenses>
   <developers>


### PR DESCRIPTION
The code is licenced under the BSD 3-clause license. The POM should point to the license in use.