### PR TITLE
Declare a full dependency on javax.mail-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,6 @@
       <groupId>javax.mail</groupId>
       <artifactId>javax.mail-api</artifactId>
       <version>1.6.2</version>
-      <scope>provided</scope>
     </dependency>
     <!-- com.sun.mail API, only used for MIME message generation -->
     <dependency>


### PR DESCRIPTION
The Mail API is required for the classloader to load the OutlookMessage class.

Without this dependency, an application will crash when the ClassLoader tries to load the `OutlookMessage` class prior to invocation of the constructor.

A minimal reproduce of the crash is available at https://github.com/MariusVolkhart/jotlmsg-repro