### PR TITLE
Fix execution on JRE 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,12 @@
       <version>1.6.2</version>
       <optional>true</optional>
     </dependency>
+    <!-- Required on Java 9 and higher since javax.activation was removed -->
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <version>1.1</version>
+    </dependency>
     <!-- Apache POI -->
     <dependency>
       <groupId>org.apache.poi</groupId>


### PR DESCRIPTION
Jotlmsg has a dependency on javax.activation because OutlookMessage makes use of it (for example, the ByteArrayDataSource). Java 9 removed the javax.activation package from the classpath. As a result, loading the OutlookMessage class on Java 11 causes a NoClassDefFoundError.

When an application declares a dependency on the optional com.sun.mail:javax.mail dependency, then the error does not manifest itself because com.sun.mail:javax.mail pulls in javax.activation:activation transitively.

On Java 8, everything works as expected, regardless of whether or not the optional dependency is specified, since javax.activation is on the classpath.